### PR TITLE
Fix zoom and pan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
-## [1.1.0] - 2021-11-09
+## [1.1.0] - 2021-11-10
+- Add Frame All to dependency graph viewer.
 - Add ProjectSettings dependency scanning
 - Add support for ASMDEF in/out references
 - Fix dependency item @type search selector resolution.
+- Fix zoom in dependency graph viewer.
 
 ## [1.0.5] - 2021-10-20
 - Add missing scripts indexer to find objects with missing scripts using `missing:scripts` or `is:broken`

--- a/Editor/Dependencies/Graph/DependencyGraphViewer.cs
+++ b/Editor/Dependencies/Graph/DependencyGraphViewer.cs
@@ -130,10 +130,10 @@ namespace UnityEditor.Search
                 zoomDelta = delta < 0 ? zoomDelta : -zoomDelta;
 
                 float oldZoom = zoom;
+                var targetLocal = e.mousePosition;
                 zoom = Mathf.Clamp(zoom + zoomDelta, 0.2f, 6.25f);
-
-                if (zoomDelta > 0)
-                    pan += (graphRect.center - e.mousePosition) * zoom;
+                var realDelta = zoom - oldZoom;
+                pan -= (targetLocal * realDelta / (oldZoom * zoom));
 
                 e.Use();
             }

--- a/Editor/Dependencies/Graph/DependencyGraphViewer.cs
+++ b/Editor/Dependencies/Graph/DependencyGraphViewer.cs
@@ -129,6 +129,26 @@ namespace UnityEditor.Search
                 float delta = e.delta.x + e.delta.y;
                 zoomDelta = delta < 0 ? zoomDelta : -zoomDelta;
 
+                // To make the zoom focus on the target point, you have to make sure that this
+                // point stays the same (in local space) after the transformations.
+                // To do this, you can solve a little linear algebra system.
+                // Let:
+                // - TPLi be the initial target point (local space)
+                // - TPLf be the final target point (local space)
+                // - TPV be the target point (view space/global space)
+                // - P1 the pan before the transformation
+                // - P2 the pan after the transformation
+                // - Z1 the zoom level before the transformation
+                // - Z2 the zoom level after the transformation
+                // Solve this system:
+                // Eq1: TPV = TPLi/Z1 - P1
+                // Eq2: Z2 = Z1 + delta
+                // Eq3: TPLf = (TPV + P2) * Z2
+                // We know that at the end, TPLf == TPLi, delta is a constant that we know,
+                // so we only need to find P2. By substituting Eq1 and Eq2 into Eq3, we get
+                // TPLf = (TPLi/Z1 - P1 + P2) * Z2
+                // 0 = TPLi*delta/Z1 - P1*Z2 + P2*Z2
+                // P2 = P1 - TPLi*delta/(Z1*Z2)
                 float oldZoom = zoom;
                 var targetLocal = e.mousePosition;
                 zoom = Mathf.Clamp(zoom + zoomDelta, 0.2f, 6.25f);


### PR DESCRIPTION
This PR fixes the zoom in the Dependency graph viewer. Additionally, it adds a "Frame All" workflow available from the contextual menu or the shortcut "F".
![dep-viewer-zoom-fixed](https://user-images.githubusercontent.com/11447060/141195453-c3b042c2-1b89-4889-91af-8929c9b480ad.gif)
![dep-viewer-frame-all](https://user-images.githubusercontent.com/11447060/141195469-1972217e-e6dc-4e2c-a9eb-b7946fafc55a.gif)


