### PR TITLE
Fix compilation for Unity 6000.5

### DIFF
--- a/package-examples/Editor/API/SearchWalker.cs
+++ b/package-examples/Editor/API/SearchWalker.cs
@@ -112,7 +112,11 @@ static class SearchWalker
 					var containerPath = AssetDatabase.GUIDToAssetPath(gid.assetGUID);
 
 					var mainInstanceID = GetMainAssetInstanceID(containerPath);
+#if UNITY_6000_5_OR_NEWER
+					AssetDatabase.OpenAsset((EntityId)mainInstanceID);
+#else
 					AssetDatabase.OpenAsset(mainInstanceID);
+#endif
 					yield return null;
 
 					var scene = UnityEngine.SceneManagement.SceneManager.GetActiveScene();

--- a/package-examples/Editor/Providers/EasySearchProviderExample.cs
+++ b/package-examples/Editor/Providers/EasySearchProviderExample.cs
@@ -108,7 +108,11 @@ static class EasySearchProviderExample
     {
         Func<UnityEngine.Object, bool> FR = r => string.Equals(AssetDatabase.GetAssetPath(r), "Library/unity editor resources", StringComparison.Ordinal);
         return EasySearchProvider.Create(ExampleProvider.res.ToString(), "Resources", Resources.FindObjectsOfTypeAll<UnityEngine.Object>().Where(FR))
+#if UNITY_6000_5_OR_NEWER
+            .SetDescriptionHandler(r => $"{r.GetType().FullName} ({(int)EntityId.ToULong(r.GetEntityId())})")
+#else
             .SetDescriptionHandler(r => $"{r.GetType().FullName} ({r.GetInstanceID()})")
+#endif
             .AddAction("select", o => Selection.activeObject = o)
             .AddAction("copy", "Copy Name", r => EditorGUIUtility.systemCopyBuffer = r.name)
             .AddOption(ShowDetailsOptions.Actions | ShowDetailsOptions.Inspector)

--- a/package/Collections/SearchCollectionTreeView.cs
+++ b/package/Collections/SearchCollectionTreeView.cs
@@ -6,6 +6,12 @@ using UnityEditor.IMGUI.Controls;
 using UnityEngine;
 using System.Reflection;
 
+#if UNITY_6000_5_OR_NEWER
+using TreeView = UnityEditor.IMGUI.Controls.TreeView<int>;
+using TreeViewItem = UnityEditor.IMGUI.Controls.TreeViewItem<int>;
+using TreeViewState = UnityEditor.IMGUI.Controls.TreeViewState<int>;
+#endif
+
 namespace UnityEditor.Search.Collections
 {
     class SearchCollectionTreeView : TreeView

--- a/package/Collections/SearchCollectionTreeViewItem.cs
+++ b/package/Collections/SearchCollectionTreeViewItem.cs
@@ -5,8 +5,12 @@ using System.Linq;
 using UnityEditor.IMGUI.Controls;
 using UnityEngine;
 
+#if UNITY_6000_5_OR_NEWER
+using TreeViewItem = UnityEditor.IMGUI.Controls.TreeViewItem<int>;
+#endif
+
 namespace UnityEditor.Search.Collections
-{ 
+{
     class SearchCollectionTreeViewItem : SearchTreeViewItem
     {
 #if UNITY_2021_2_OR_NEWER

--- a/package/Collections/SearchCollectionView.cs
+++ b/package/Collections/SearchCollectionView.cs
@@ -5,6 +5,10 @@ using System.Collections.Generic;
 using UnityEditor.IMGUI.Controls;
 using UnityEngine;
 
+#if UNITY_6000_5_OR_NEWER
+using TreeViewState = UnityEditor.IMGUI.Controls.TreeViewState<int>;
+#endif
+
 namespace UnityEditor.Search.Collections
 {
     interface ISearchCollectionHostView

--- a/package/Collections/SearchTreeViewItem.cs
+++ b/package/Collections/SearchTreeViewItem.cs
@@ -4,6 +4,10 @@ using System.Linq;
 using UnityEditor.IMGUI.Controls;
 using UnityEngine;
 
+#if UNITY_6000_5_OR_NEWER
+using TreeViewItem = UnityEditor.IMGUI.Controls.TreeViewItem<int>;
+#endif
+
 namespace UnityEditor.Search.Collections
 {
     class SearchTreeViewItem : TreeViewItem

--- a/package/Dependencies/Dependency.cs
+++ b/package/Dependencies/Dependency.cs
@@ -284,7 +284,7 @@ namespace UnityEditor.Search
         internal static IEnumerable<string> EnumerateIdFromObjects(IEnumerable<UnityEngine.Object> objects)
         {
             foreach (var obj in objects)
-                yield return GlobalObjectId.GetGlobalObjectIdSlow(obj.GetInstanceID()).ToString();
+                yield return GlobalObjectId.GetGlobalObjectIdSlow(obj).ToString();
         }
 
         internal static IEnumerable<string> EnumeratePaths(IEnumerable<string> globalIds)
@@ -304,14 +304,22 @@ namespace UnityEditor.Search
 
                 var info = new IdInfo();
                 info.globalId = gid.ToString();
+#if UNITY_6000_5_OR_NEWER
+                info.instanceID = GlobalObjectId.GlobalObjectIdentifierToEntityIdSlow(gid);
+#else
                 info.instanceID = GlobalObjectId.GlobalObjectIdentifierToInstanceIDSlow(gid);
+#endif
                 info.path = AssetDatabase.GetAssetPath(info.instanceID);
                 if (!string.IsNullOrEmpty(info.path))
                 {
                     info.isAssetId = true;
                     yield return info;
                 }
+#if UNITY_6000_5_OR_NEWER
+                else if (EditorUtility.EntityIdToObject(info.instanceID) is UnityEngine.Object obj)
+#else
                 else if (EditorUtility.InstanceIDToObject(info.instanceID) is UnityEngine.Object obj)
+#endif
                 {
                     info.path = SearchUtils.GetObjectPath(obj).Substring(1);
                     yield return info;

--- a/package/Dependencies/DependencyBuiltinStates.cs
+++ b/package/Dependencies/DependencyBuiltinStates.cs
@@ -138,7 +138,12 @@ namespace UnityEditor.Search
                 if (idInfo.isAssetId)
                     selectedPaths.Add($"\"{idInfo.path}\"");
                 else
+#if UNITY_6000_5_OR_NEWER
+                    // Keep the int wire format: the lower 32 bits of an EntityId hold the legacy instance id.
+                    selectedInstanceIds.Add((int)EntityId.ToULong(idInfo.instanceID));
+#else
                     selectedInstanceIds.Add(idInfo.instanceID);
+#endif
             }
 
             var fetchSceneRefs = config.flags.HasFlag(DependencyViewerFlags.ShowSceneRefs);
@@ -159,7 +164,11 @@ namespace UnityEditor.Search
             var state = new DependencyViewerState(stateName, idsOfInterest) { config = config };
             if (selectedInstanceIds.Count == 1)
             {
+#if UNITY_6000_5_OR_NEWER
+                var selectedObject = EditorUtility.EntityIdToObject(selectedInstanceIds.First());
+#else
                 var selectedObject = EditorUtility.InstanceIDToObject(selectedInstanceIds.First());
+#endif
                 var thumbnail = AssetPreview.GetMiniThumbnail(selectedObject);
                 state.windowTitle = new GUIContent(selectedObject.name, thumbnail);
                 if (selectedObject is GameObject go)

--- a/package/Dependencies/DependencyExtensions.cs
+++ b/package/Dependencies/DependencyExtensions.cs
@@ -60,11 +60,15 @@ namespace UnityEditor.Search
 
         static IEnumerable<SearchItem> GetSceneObjectDependencies(SearchContext context, SearchProvider sceneProvider, SearchProvider depProvider, int instanceId)
         {
+#if UNITY_6000_5_OR_NEWER
+            var obj = EditorUtility.EntityIdToObject(instanceId);
+#else
             var obj = EditorUtility.InstanceIDToObject(instanceId);
+#endif
             if (!obj)
                 yield break;
 
-            var go = EditorUtility.InstanceIDToObject(instanceId) as GameObject;
+            var go = obj as GameObject;
             if (!go && obj is Component goc)
             {
                 foreach (var ce in GetComponentDependencies(context, sceneProvider, depProvider, goc))
@@ -149,7 +153,11 @@ namespace UnityEditor.Search
                 if (!string.IsNullOrEmpty(assetPath))
                     yielder(SearchExpression.CreateItem(assetPath));
                 else
+#if UNITY_6000_5_OR_NEWER
+                    yielder(SearchExpression.CreateItem((int)EntityId.ToULong(obj.GetEntityId())));
+#else
                     yielder(SearchExpression.CreateItem(obj.GetInstanceID()));
+#endif
                 #else
                 if (!string.IsNullOrEmpty(assetPath))
                     yielder(EvaluatorUtils.CreateItem(assetPath));

--- a/package/Dependencies/DependencyTableViewIMGUI.cs
+++ b/package/Dependencies/DependencyTableViewIMGUI.cs
@@ -1,4 +1,5 @@
-#if !UNITY_7000_0_OR_NEWER
+// PropertyTable (IMGUI) was deprecated in 6000.5; this view is only used below 2023.1 (see DependencyViewer.CreateTableView).
+#if !UNITY_6000_5_OR_NEWER
 #pragma warning disable CS0618
 using System.Collections.Generic;
 using System;

--- a/package/Dependencies/DependencyViewerState.cs
+++ b/package/Dependencies/DependencyViewerState.cs
@@ -23,7 +23,11 @@ namespace UnityEditor.Search
     {
         public string globalId;
         public string path;
+#if UNITY_6000_5_OR_NEWER
+        public EntityId instanceID;
+#else
         public int instanceID;
+#endif
         public bool isAssetId;
     }
 
@@ -178,12 +182,21 @@ namespace UnityEditor.Search
             {
                 if (!GlobalObjectId.TryParse(sgid, out var gid))
                     continue;
+#if UNITY_6000_5_OR_NEWER
+                var instanceId = GlobalObjectId.GlobalObjectIdentifierToEntityIdSlow(gid);
+                var assetPath = AssetDatabase.GetAssetPath(instanceId);
+                if (!string.IsNullOrEmpty(assetPath))
+                    yield return assetPath;
+                else if (EditorUtility.EntityIdToObject(instanceId) is UnityEngine.Object obj)
+                    yield return SearchUtils.GetObjectPath(obj).Substring(1);
+#else
                 var instanceId = GlobalObjectId.GlobalObjectIdentifierToInstanceIDSlow(gid);
                 var assetPath = AssetDatabase.GetAssetPath(instanceId);
                 if (!string.IsNullOrEmpty(assetPath))
                     yield return assetPath;
                 else if (EditorUtility.InstanceIDToObject(instanceId) is UnityEngine.Object obj)
                     yield return SearchUtils.GetObjectPath(obj).Substring(1);
+#endif
             }
         }
     }

--- a/package/Dependencies/Graph/DependencyGraphViewer.cs
+++ b/package/Dependencies/Graph/DependencyGraphViewer.cs
@@ -548,7 +548,7 @@ namespace UnityEditor.Search
                     {
                         selectedNode = node;
                         if (selectedObject)
-                            EditorGUIUtility.PingObject(selectedObject.GetInstanceID());
+                            EditorGUIUtility.PingObject(selectedObject);
                     }
                     else if (evt.clickCount == 2)
                     {

--- a/package/Dependencies/Graph/DependencyUtilities.cs
+++ b/package/Dependencies/Graph/DependencyUtilities.cs
@@ -123,6 +123,8 @@ namespace UnityEditor.Search
         {
 #if !USE_SEARCH_EXTENSION_API
             return Utils.GetMainAssetInstanceID(path);
+#elif UNITY_6000_5_OR_NEWER
+            return (int)EntityId.ToULong(SearchUtils.GetMainAssetEntityId(path));
 #else
             return SearchUtils.GetMainAssetInstanceID(path);
 #endif

--- a/package/Dependencies/SearchViewModelEx.cs
+++ b/package/Dependencies/SearchViewModelEx.cs
@@ -98,6 +98,11 @@ namespace UnityEditor.Search
 #else
         public int viewId { get; set; }
 #endif
+
+#if UNITY_6000_5_OR_NEWER
+        string m_CurrentResultViewId;
+        string ISearchView.currentResultViewId { get => m_CurrentResultViewId; set => m_CurrentResultViewId = value; }
+#endif
         public Action<GenericMenu, SearchItem> addToItemContextualMenu;
         public Action<SearchAction, SearchItem[], bool> executeAction;
         #endregion

--- a/package/Overlays/SearchViewElement.cs
+++ b/package/Overlays/SearchViewElement.cs
@@ -230,6 +230,11 @@ namespace UnityEditor.Search
             throw new NotImplementedException();
         }
 
+#if UNITY_6000_5_OR_NEWER
+        string m_CurrentResultViewId;
+        string ISearchView.currentResultViewId { get => m_CurrentResultViewId; set => m_CurrentResultViewId = value; }
+#endif
+
 #if UNITY_6000_4_OR_NEWER
         EntityId ISearchView.GetViewId()
         {


### PR DESCRIPTION
## Summary

The packages no longer compile with Unity 6000.5 (tested with 6000.5.2f1): several APIs that were previously deprecated became compile errors (`[Obsolete(..., error: true)]`). This PR fixes compilation for 6000.5 while keeping the existing behavior on older versions (everything is gated behind `UNITY_6000_5_OR_NEWER`).

### What broke and how it is fixed

| 6000.5 change | Fix |
| --- | --- |
| Non-generic IMGUI `TreeView` / `TreeViewItem` / `TreeViewState` are obsolete (error) | Alias them to the generic `TreeView<int>` family on 6000.5+ in the `Collections` views (the generic API mirrors the old one, including the internal `controller` property accessed via reflection) |
| `PropertyTable` is obsolete (error, "IMGUI is not supported anymore") | Stop compiling `DependencyTableViewIMGUI` on 6000.5+. It is dead code there: `DependencyViewer.CreateTableView` only instantiates it below 2023.1, where `DependencyTableViewUITk` takes over |
| `ISearchView` gained a `string currentResultViewId { get; set; }` member | Implemented in `SearchViewModelEx` and `SearchViewElement` (explicit implementation with a backing field — the member is internal, so an implicit implementation does not compile under C# 9) |
| `Object.GetInstanceID()`, `EditorUtility.InstanceIDToObject(int)`, `AssetDatabase.GetAssetPath(int)` / `OpenAsset(int)`, `EditorGUIUtility.PingObject(int)`, `GlobalObjectId` int-based helpers, and the `EntityId -> int` implicit conversion are obsolete (error) | Migrated to the `EntityId`-based equivalents on 6000.5+. Where an `Object` overload already existed (`GetGlobalObjectIdSlow`, `PingObject`), it is now used unconditionally, which works on all supported versions |

### Note on the `EntityId` migration

`EntityId.ToString()` returns the raw 64-bit value (magic version in the upper 32 bits), so `EntityId` values cannot be dropped into the dependency query strings (`deps{[...]}`) that previously carried int instance ids. Since both the producer (`DependencyBuiltinStates`) and the consumer (the `deps` search expression evaluator) live in this package, the int wire format is kept on 6000.5 by extracting the lower 32 bits via the non-obsolete `EntityId.ToULong()` (same value the removed implicit `int` conversion produced).

## Testing

Compiled `projects/SearchExtensionsExamples` (which pulls in `package`, `package-examples`, and `package-queries`) in batch mode:

- **6000.5.2f1** — 0 compile errors (was ~20 before this change)
- **6000.4.3f1** — still compiles (all changes are `#if`-gated)
- **2022.3.62f2** — still compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)
